### PR TITLE
Implement Redis for Blacklisted-token caching

### DIFF
--- a/frontend/src/components/DashboardPage.js
+++ b/frontend/src/components/DashboardPage.js
@@ -75,6 +75,7 @@ function Dashboard() {
 	const verifyCookie = async () => {
 		const endpoint = URL_USER_SVC_DASHBOARD;
 		const res = await axios.get(endpoint).catch((err) => {
+			console.log(err)
 			if (err.response.status === STATUS_CODE_UNAUTHORIZED) {
 				setErrorDialog("User not authorized!");
 			} else {

--- a/user-service/controller/user-controller.js
+++ b/user-service/controller/user-controller.js
@@ -5,6 +5,8 @@ import { ormUpdateUser as _updateUser } from "../model/user-orm.js";
 import bcrypt from "bcryptjs";
 import jwt from "jsonwebtoken";
 import userModel from "../model/user-model.js";
+import { redisClient } from "../index.js";
+import redis from "redis";
 
 export async function createUser(req, res) {
 	try {
@@ -80,6 +82,8 @@ export async function deleteUser(req, res) {
 						.status(400)
 						.json({ message: "Could not delete user!" });
 				} else {
+					let token = req.cookies.token;
+					redisClient.setEx(username, 3600, token);
 					res.clearCookie("token");
 					console.log(`Deleted user ${username} successfully!`);
 					return res.status(200).json({
@@ -143,6 +147,8 @@ export async function logoutUser(req, res) {
 				message: "User not found! Try again.",
 			});
 		} else {
+			let token = req.cookies.token;
+			redisClient.setEx(token, 3600, username);
 			res.clearCookie("token");
 			res.status(200).json({
 				message: "Successfully Logged out user"

--- a/user-service/index.js
+++ b/user-service/index.js
@@ -2,9 +2,15 @@ import express from "express";
 import cors from "cors";
 import cookieParser from "cookie-parser";
 import { authProtect } from "./middleware/authMiddleware.js";
+import redis from "redis";
 
 const app = express();
 const endpoint = process.env.PORT
+
+export const redisClient = redis.createClient()
+await redisClient.connect()
+
+
 app.use(express.urlencoded({ extended: true }));
 app.use(express.json());
 app.use(cors({ credentials: true, origin: endpoint})); // config cors so that front-end can use

--- a/user-service/middleware/authMiddleware.js
+++ b/user-service/middleware/authMiddleware.js
@@ -1,13 +1,21 @@
 import jwt from "jsonwebtoken";
 import asyncHandler from "express-async-handler"
 import UserModel from "../model/user-model.js";
-
+import { redisClient } from "../index.js";
+import redis from "redis";
 
 export const authProtect = asyncHandler(async(req, res, next) => {
     const token = req.cookies.token
+    console.log(token)
 
     if (!token) {
         return res.status(401).send("Access Denied: No token provided");
+    }
+
+    const inBlackList = await redisClient.get(token);
+
+    if (inBlackList) {
+        return res.status(401).send("Access Denied: Token is blacklisted");
     }
 
     try {

--- a/user-service/package-lock.json
+++ b/user-service/package-lock.json
@@ -10,13 +10,17 @@
 			"license": "ISC",
 			"dependencies": {
 				"bcryptjs": "^2.4.3",
+				"body-parser": "^1.20.0",
 				"cookie-parser": "^1.4.6",
 				"cors": "^2.8.5",
 				"dotenv": "^16.0.1",
 				"express": "^4.18.1",
 				"express-async-handler": "^1.2.0",
+				"express-jwt-blacklist": "^1.1.0",
 				"jsonwebtoken": "^8.5.1",
 				"mongoose": "^6.4.5",
+				"redis": "^4.3.1",
+				"redis-server": "^1.2.2",
 				"require": "^2.4.20"
 			},
 			"devDependencies": {
@@ -38,6 +42,59 @@
 			"dev": true,
 			"dependencies": {
 				"@hapi/hoek": "^9.0.0"
+			}
+		},
+		"node_modules/@redis/bloom": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-1.0.2.tgz",
+			"integrity": "sha512-EBw7Ag1hPgFzdznK2PBblc1kdlj5B5Cw3XwI9/oG7tSn85/HKy3X9xHy/8tm/eNXJYHLXHJL/pkwBpFMVVefkw==",
+			"peerDependencies": {
+				"@redis/client": "^1.0.0"
+			}
+		},
+		"node_modules/@redis/client": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@redis/client/-/client-1.3.0.tgz",
+			"integrity": "sha512-XCFV60nloXAefDsPnYMjHGtvbtHR8fV5Om8cQ0JYqTNbWcQo/4AryzJ2luRj4blveWazRK/j40gES8M7Cp6cfQ==",
+			"dependencies": {
+				"cluster-key-slot": "1.1.0",
+				"generic-pool": "3.8.2",
+				"yallist": "4.0.0"
+			},
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/@redis/graph": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@redis/graph/-/graph-1.0.1.tgz",
+			"integrity": "sha512-oDE4myMCJOCVKYMygEMWuriBgqlS5FqdWerikMoJxzmmTUErnTRRgmIDa2VcgytACZMFqpAOWDzops4DOlnkfQ==",
+			"peerDependencies": {
+				"@redis/client": "^1.0.0"
+			}
+		},
+		"node_modules/@redis/json": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@redis/json/-/json-1.0.4.tgz",
+			"integrity": "sha512-LUZE2Gdrhg0Rx7AN+cZkb1e6HjoSKaeeW8rYnt89Tly13GBI5eP4CwDVr+MY8BAYfCg4/N15OUrtLoona9uSgw==",
+			"peerDependencies": {
+				"@redis/client": "^1.0.0"
+			}
+		},
+		"node_modules/@redis/search": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@redis/search/-/search-1.1.0.tgz",
+			"integrity": "sha512-NyFZEVnxIJEybpy+YskjgOJRNsfTYqaPbK/Buv6W2kmFNaRk85JiqjJZA5QkRmWvGbyQYwoO5QfDi2wHskKrQQ==",
+			"peerDependencies": {
+				"@redis/client": "^1.0.0"
+			}
+		},
+		"node_modules/@redis/time-series": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-1.0.3.tgz",
+			"integrity": "sha512-OFp0q4SGrTH0Mruf6oFsHGea58u8vS/iI5+NpYdicaM+7BgqBZH8FFvNZ8rYYLrUO/QRqMq72NpXmxLVNcdmjA==",
+			"peerDependencies": {
+				"@redis/client": "^1.0.0"
 			}
 		},
 		"node_modules/@sideway/address": {
@@ -356,6 +413,14 @@
 				"wrap-ansi": "^7.0.0"
 			}
 		},
+		"node_modules/cluster-key-slot": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.0.tgz",
+			"integrity": "sha512-2Nii8p3RwAPiFwsnZvukotvow2rIHM+yQ6ZcBXGHdniadkYGZYiGmkHJIbZPIV9nfv7m/U1IPMVVcAhoWFeklw==",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/color-convert": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -379,6 +444,11 @@
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
 			"dev": true
+		},
+		"node_modules/connection-parse": {
+			"version": "0.0.7",
+			"resolved": "https://registry.npmjs.org/connection-parse/-/connection-parse-0.0.7.tgz",
+			"integrity": "sha512-bTTG28diWg7R7/+qE5NZumwPbCiJOT8uPdZYu674brDjBWQctbaQbYlDKhalS+4i5HxIx+G8dZsnBHKzWpp01A=="
 		},
 		"node_modules/content-disposition": {
 			"version": "0.5.4",
@@ -495,6 +565,11 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/double-ended-queue": {
+			"version": "2.1.0-0",
+			"resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz",
+			"integrity": "sha512-+BNfZ+deCo8hMNpDqDnvT+c0XpJ5cUa6mqYq89bho2Ifze4URTqRkcwR399hWoTrTkbZ/XJYDgP6rc7pRgffEQ=="
+		},
 		"node_modules/ecdsa-sig-formatter": {
 			"version": "1.0.11",
 			"resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
@@ -589,6 +664,28 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/express-async-handler/-/express-async-handler-1.2.0.tgz",
 			"integrity": "sha512-rCSVtPXRmQSW8rmik/AIb2P0op6l7r1fMW538yyvTMltCO4xQEWMmobfrIxN2V1/mVrgxB8Az3reYF6yUZw37w=="
+		},
+		"node_modules/express-jwt-blacklist": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/express-jwt-blacklist/-/express-jwt-blacklist-1.1.0.tgz",
+			"integrity": "sha512-RkE6GIp4QJDpNceSIVUzfyc26FEzakBI2IBOTb+GVczjspwgnDGozE8KWZeTg/2/rMBfG5aSTtB+6O8RIp5QOA==",
+			"dependencies": {
+				"memcached": "^2.2.1",
+				"redis": "^2.5.3"
+			}
+		},
+		"node_modules/express-jwt-blacklist/node_modules/redis": {
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/redis/-/redis-2.8.0.tgz",
+			"integrity": "sha512-M1OkonEQwtRmZv4tEWF2VgpG0JWJ8Fv1PhlgT5+B+uNq2cA3Rt1Yt/ryoR+vQNOQcIEgdCdfH0jr3bDpihAw1A==",
+			"dependencies": {
+				"double-ended-queue": "^2.1.0-0",
+				"redis-commands": "^1.2.0",
+				"redis-parser": "^2.6.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
 		},
 		"node_modules/express/node_modules/debug": {
 			"version": "2.6.9",
@@ -700,6 +797,14 @@
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
 			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
 		},
+		"node_modules/generic-pool": {
+			"version": "3.8.2",
+			"resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.8.2.tgz",
+			"integrity": "sha512-nGToKy6p3PAbYQ7p1UlWl6vSPwfwU6TMSWK7TTu+WUY4ZjyZQGniGGt2oNVvyNSpyZYSB43zMXVLcBm08MTMkg==",
+			"engines": {
+				"node": ">= 4"
+			}
+		},
 		"node_modules/get-caller-file": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -763,6 +868,15 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/hashring": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/hashring/-/hashring-3.2.0.tgz",
+			"integrity": "sha512-xCMovURClsQZ+TR30icCZj+34Fq1hs0y6YCASD6ZqdRfYRybb5Iadws2WS+w09mGM/kf9xyA5FCdJQGcgcraSA==",
+			"dependencies": {
+				"connection-parse": "0.0.x",
+				"simple-lru-cache": "0.0.x"
 			}
 		},
 		"node_modules/http-errors": {
@@ -885,6 +999,14 @@
 				"node": ">=0.12.0"
 			}
 		},
+		"node_modules/jackpot": {
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/jackpot/-/jackpot-0.0.6.tgz",
+			"integrity": "sha512-rbWXX+A9ooq03/dfavLg9OXQ8YB57Wa7PY5c4LfU3CgFpwEhhl3WyXTQVurkaT7zBM5I9SSOaiLyJ4I0DQmC0g==",
+			"dependencies": {
+				"retry": "0.6.0"
+			}
+		},
 		"node_modules/jest-docblock": {
 			"version": "27.5.1",
 			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-27.5.1.tgz",
@@ -1002,6 +1124,15 @@
 			"integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
 			"engines": {
 				"node": ">= 0.6"
+			}
+		},
+		"node_modules/memcached": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/memcached/-/memcached-2.2.2.tgz",
+			"integrity": "sha512-lHwUmqkT9WdUUgRsAvquO4xsKXYaBd644Orz31tuth+w/BIfFNuJMWwsG7sa7H3XXytaNfPTZ5R/yOG3d9zJMA==",
+			"dependencies": {
+				"hashring": "3.2.x",
+				"jackpot": ">=0.0.6"
 			}
 		},
 		"node_modules/memory-pager": {
@@ -1323,6 +1454,14 @@
 				"prettier": "^2.0.0"
 			}
 		},
+		"node_modules/promise-queue": {
+			"version": "2.2.5",
+			"resolved": "https://registry.npmjs.org/promise-queue/-/promise-queue-2.2.5.tgz",
+			"integrity": "sha512-p/iXrPSVfnqPft24ZdNNLECw/UrtLTpT3jpAAMzl/o5/rDsGCPo3/CQS2611flL6LkoEJ3oQZw7C8Q80ZISXRQ==",
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
 		"node_modules/proxy-addr": {
 			"version": "2.0.7",
 			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -1397,6 +1536,43 @@
 				"node": ">=8.10.0"
 			}
 		},
+		"node_modules/redis": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/redis/-/redis-4.3.1.tgz",
+			"integrity": "sha512-cM7yFU5CA6zyCF7N/+SSTcSJQSRMEKN0k0Whhu6J7n9mmXRoXugfWDBo5iOzGwABmsWKSwGPTU5J4Bxbl+0mrA==",
+			"dependencies": {
+				"@redis/bloom": "1.0.2",
+				"@redis/client": "1.3.0",
+				"@redis/graph": "1.0.1",
+				"@redis/json": "1.0.4",
+				"@redis/search": "1.1.0",
+				"@redis/time-series": "1.0.3"
+			}
+		},
+		"node_modules/redis-commands": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
+			"integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ=="
+		},
+		"node_modules/redis-parser": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-2.6.0.tgz",
+			"integrity": "sha512-9Hdw19gwXFBJdN8ENUoNVJFRyMDFrE/ZBClPicKYDPwNPJ4ST1TedAHYNSiGKElwh2vrmRGMoJYbVdJd+WQXIw==",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/redis-server": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/redis-server/-/redis-server-1.2.2.tgz",
+			"integrity": "sha512-pOaSIeSMVFkEFIuaMtpQ3TOr3uI4sUmEHm4ofGks5vTPRseHUszxyIlC70IFjUR9qSeH8o/ARZEM8dqcJmgGJw==",
+			"dependencies": {
+				"promise-queue": "^2.2.5"
+			},
+			"engines": {
+				"node": ">=4.0.0"
+			}
+		},
 		"node_modules/require": {
 			"version": "2.4.20",
 			"resolved": "https://registry.npmjs.org/require/-/require-2.4.20.tgz",
@@ -1420,6 +1596,14 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/retry": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/retry/-/retry-0.6.0.tgz",
+			"integrity": "sha512-RgncoxLF1GqwAzTZs/K2YpZkWrdIYbXsmesdomi+iPilSzjUyr/wzNIuteoTVaWokzdwZIJ9NHRNQa/RUiOB2g==",
+			"engines": {
+				"node": "*"
 			}
 		},
 		"node_modules/rxjs": {
@@ -1550,6 +1734,11 @@
 			"version": "16.0.0",
 			"resolved": "https://registry.npmjs.org/sift/-/sift-16.0.0.tgz",
 			"integrity": "sha512-ILTjdP2Mv9V1kIxWMXeMTIRbOBrqKc4JAXmFMnFq3fKeyQ2Qwa3Dw1ubcye3vR+Y6ofA0b9gNDr/y2t6eUeIzQ=="
+		},
+		"node_modules/simple-lru-cache": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/simple-lru-cache/-/simple-lru-cache-0.0.2.tgz",
+			"integrity": "sha512-uEv/AFO0ADI7d99OHDmh1QfYzQk/izT1vCmu/riQfh7qjBVUUgRT87E5s5h7CxWCA/+YoZerykpEthzVrW3LIw=="
 		},
 		"node_modules/simple-update-notifier": {
 			"version": "1.0.7",
@@ -1848,6 +2037,11 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/yallist": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+		},
 		"node_modules/yargs": {
 			"version": "17.5.1",
 			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.5.1.tgz",
@@ -1891,6 +2085,46 @@
 			"requires": {
 				"@hapi/hoek": "^9.0.0"
 			}
+		},
+		"@redis/bloom": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-1.0.2.tgz",
+			"integrity": "sha512-EBw7Ag1hPgFzdznK2PBblc1kdlj5B5Cw3XwI9/oG7tSn85/HKy3X9xHy/8tm/eNXJYHLXHJL/pkwBpFMVVefkw==",
+			"requires": {}
+		},
+		"@redis/client": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@redis/client/-/client-1.3.0.tgz",
+			"integrity": "sha512-XCFV60nloXAefDsPnYMjHGtvbtHR8fV5Om8cQ0JYqTNbWcQo/4AryzJ2luRj4blveWazRK/j40gES8M7Cp6cfQ==",
+			"requires": {
+				"cluster-key-slot": "1.1.0",
+				"generic-pool": "3.8.2",
+				"yallist": "4.0.0"
+			}
+		},
+		"@redis/graph": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@redis/graph/-/graph-1.0.1.tgz",
+			"integrity": "sha512-oDE4myMCJOCVKYMygEMWuriBgqlS5FqdWerikMoJxzmmTUErnTRRgmIDa2VcgytACZMFqpAOWDzops4DOlnkfQ==",
+			"requires": {}
+		},
+		"@redis/json": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@redis/json/-/json-1.0.4.tgz",
+			"integrity": "sha512-LUZE2Gdrhg0Rx7AN+cZkb1e6HjoSKaeeW8rYnt89Tly13GBI5eP4CwDVr+MY8BAYfCg4/N15OUrtLoona9uSgw==",
+			"requires": {}
+		},
+		"@redis/search": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@redis/search/-/search-1.1.0.tgz",
+			"integrity": "sha512-NyFZEVnxIJEybpy+YskjgOJRNsfTYqaPbK/Buv6W2kmFNaRk85JiqjJZA5QkRmWvGbyQYwoO5QfDi2wHskKrQQ==",
+			"requires": {}
+		},
+		"@redis/time-series": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-1.0.3.tgz",
+			"integrity": "sha512-OFp0q4SGrTH0Mruf6oFsHGea58u8vS/iI5+NpYdicaM+7BgqBZH8FFvNZ8rYYLrUO/QRqMq72NpXmxLVNcdmjA==",
+			"requires": {}
 		},
 		"@sideway/address": {
 			"version": "4.1.4",
@@ -2134,6 +2368,11 @@
 				"wrap-ansi": "^7.0.0"
 			}
 		},
+		"cluster-key-slot": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.0.tgz",
+			"integrity": "sha512-2Nii8p3RwAPiFwsnZvukotvow2rIHM+yQ6ZcBXGHdniadkYGZYiGmkHJIbZPIV9nfv7m/U1IPMVVcAhoWFeklw=="
+		},
 		"color-convert": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2154,6 +2393,11 @@
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
 			"dev": true
+		},
+		"connection-parse": {
+			"version": "0.0.7",
+			"resolved": "https://registry.npmjs.org/connection-parse/-/connection-parse-0.0.7.tgz",
+			"integrity": "sha512-bTTG28diWg7R7/+qE5NZumwPbCiJOT8uPdZYu674brDjBWQctbaQbYlDKhalS+4i5HxIx+G8dZsnBHKzWpp01A=="
 		},
 		"content-disposition": {
 			"version": "0.5.4",
@@ -2237,6 +2481,11 @@
 			"version": "16.0.1",
 			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.1.tgz",
 			"integrity": "sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ=="
+		},
+		"double-ended-queue": {
+			"version": "2.1.0-0",
+			"resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz",
+			"integrity": "sha512-+BNfZ+deCo8hMNpDqDnvT+c0XpJ5cUa6mqYq89bho2Ifze4URTqRkcwR399hWoTrTkbZ/XJYDgP6rc7pRgffEQ=="
 		},
 		"ecdsa-sig-formatter": {
 			"version": "1.0.11",
@@ -2336,6 +2585,27 @@
 			"resolved": "https://registry.npmjs.org/express-async-handler/-/express-async-handler-1.2.0.tgz",
 			"integrity": "sha512-rCSVtPXRmQSW8rmik/AIb2P0op6l7r1fMW538yyvTMltCO4xQEWMmobfrIxN2V1/mVrgxB8Az3reYF6yUZw37w=="
 		},
+		"express-jwt-blacklist": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/express-jwt-blacklist/-/express-jwt-blacklist-1.1.0.tgz",
+			"integrity": "sha512-RkE6GIp4QJDpNceSIVUzfyc26FEzakBI2IBOTb+GVczjspwgnDGozE8KWZeTg/2/rMBfG5aSTtB+6O8RIp5QOA==",
+			"requires": {
+				"memcached": "^2.2.1",
+				"redis": "^2.5.3"
+			},
+			"dependencies": {
+				"redis": {
+					"version": "2.8.0",
+					"resolved": "https://registry.npmjs.org/redis/-/redis-2.8.0.tgz",
+					"integrity": "sha512-M1OkonEQwtRmZv4tEWF2VgpG0JWJ8Fv1PhlgT5+B+uNq2cA3Rt1Yt/ryoR+vQNOQcIEgdCdfH0jr3bDpihAw1A==",
+					"requires": {
+						"double-ended-queue": "^2.1.0-0",
+						"redis-commands": "^1.2.0",
+						"redis-parser": "^2.6.0"
+					}
+				}
+			}
+		},
 		"fill-range": {
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -2402,6 +2672,11 @@
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
 			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
 		},
+		"generic-pool": {
+			"version": "3.8.2",
+			"resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.8.2.tgz",
+			"integrity": "sha512-nGToKy6p3PAbYQ7p1UlWl6vSPwfwU6TMSWK7TTu+WUY4ZjyZQGniGGt2oNVvyNSpyZYSB43zMXVLcBm08MTMkg=="
+		},
 		"get-caller-file": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -2445,6 +2720,15 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
 			"integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
+		},
+		"hashring": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/hashring/-/hashring-3.2.0.tgz",
+			"integrity": "sha512-xCMovURClsQZ+TR30icCZj+34Fq1hs0y6YCASD6ZqdRfYRybb5Iadws2WS+w09mGM/kf9xyA5FCdJQGcgcraSA==",
+			"requires": {
+				"connection-parse": "0.0.x",
+				"simple-lru-cache": "0.0.x"
+			}
 		},
 		"http-errors": {
 			"version": "2.0.0",
@@ -2527,6 +2811,14 @@
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
 			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
 			"dev": true
+		},
+		"jackpot": {
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/jackpot/-/jackpot-0.0.6.tgz",
+			"integrity": "sha512-rbWXX+A9ooq03/dfavLg9OXQ8YB57Wa7PY5c4LfU3CgFpwEhhl3WyXTQVurkaT7zBM5I9SSOaiLyJ4I0DQmC0g==",
+			"requires": {
+				"retry": "0.6.0"
+			}
 		},
 		"jest-docblock": {
 			"version": "27.5.1",
@@ -2636,6 +2928,15 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
 			"integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ=="
+		},
+		"memcached": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/memcached/-/memcached-2.2.2.tgz",
+			"integrity": "sha512-lHwUmqkT9WdUUgRsAvquO4xsKXYaBd644Orz31tuth+w/BIfFNuJMWwsG7sa7H3XXytaNfPTZ5R/yOG3d9zJMA==",
+			"requires": {
+				"hashring": "3.2.x",
+				"jackpot": ">=0.0.6"
+			}
 		},
 		"memory-pager": {
 			"version": "1.5.0",
@@ -2852,6 +3153,11 @@
 				"yargs": "^17.0.0"
 			}
 		},
+		"promise-queue": {
+			"version": "2.2.5",
+			"resolved": "https://registry.npmjs.org/promise-queue/-/promise-queue-2.2.5.tgz",
+			"integrity": "sha512-p/iXrPSVfnqPft24ZdNNLECw/UrtLTpT3jpAAMzl/o5/rDsGCPo3/CQS2611flL6LkoEJ3oQZw7C8Q80ZISXRQ=="
+		},
 		"proxy-addr": {
 			"version": "2.0.7",
 			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -2905,6 +3211,37 @@
 				"picomatch": "^2.2.1"
 			}
 		},
+		"redis": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/redis/-/redis-4.3.1.tgz",
+			"integrity": "sha512-cM7yFU5CA6zyCF7N/+SSTcSJQSRMEKN0k0Whhu6J7n9mmXRoXugfWDBo5iOzGwABmsWKSwGPTU5J4Bxbl+0mrA==",
+			"requires": {
+				"@redis/bloom": "1.0.2",
+				"@redis/client": "1.3.0",
+				"@redis/graph": "1.0.1",
+				"@redis/json": "1.0.4",
+				"@redis/search": "1.1.0",
+				"@redis/time-series": "1.0.3"
+			}
+		},
+		"redis-commands": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
+			"integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ=="
+		},
+		"redis-parser": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-2.6.0.tgz",
+			"integrity": "sha512-9Hdw19gwXFBJdN8ENUoNVJFRyMDFrE/ZBClPicKYDPwNPJ4ST1TedAHYNSiGKElwh2vrmRGMoJYbVdJd+WQXIw=="
+		},
+		"redis-server": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/redis-server/-/redis-server-1.2.2.tgz",
+			"integrity": "sha512-pOaSIeSMVFkEFIuaMtpQ3TOr3uI4sUmEHm4ofGks5vTPRseHUszxyIlC70IFjUR9qSeH8o/ARZEM8dqcJmgGJw==",
+			"requires": {
+				"promise-queue": "^2.2.5"
+			}
+		},
 		"require": {
 			"version": "2.4.20",
 			"resolved": "https://registry.npmjs.org/require/-/require-2.4.20.tgz",
@@ -2919,6 +3256,11 @@
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
 			"integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
 			"dev": true
+		},
+		"retry": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/retry/-/retry-0.6.0.tgz",
+			"integrity": "sha512-RgncoxLF1GqwAzTZs/K2YpZkWrdIYbXsmesdomi+iPilSzjUyr/wzNIuteoTVaWokzdwZIJ9NHRNQa/RUiOB2g=="
 		},
 		"rxjs": {
 			"version": "6.6.7",
@@ -3020,6 +3362,11 @@
 			"version": "16.0.0",
 			"resolved": "https://registry.npmjs.org/sift/-/sift-16.0.0.tgz",
 			"integrity": "sha512-ILTjdP2Mv9V1kIxWMXeMTIRbOBrqKc4JAXmFMnFq3fKeyQ2Qwa3Dw1ubcye3vR+Y6ofA0b9gNDr/y2t6eUeIzQ=="
+		},
+		"simple-lru-cache": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/simple-lru-cache/-/simple-lru-cache-0.0.2.tgz",
+			"integrity": "sha512-uEv/AFO0ADI7d99OHDmh1QfYzQk/izT1vCmu/riQfh7qjBVUUgRT87E5s5h7CxWCA/+YoZerykpEthzVrW3LIw=="
 		},
 		"simple-update-notifier": {
 			"version": "1.0.7",
@@ -3233,6 +3580,11 @@
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
 			"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
 			"dev": true
+		},
+		"yallist": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
 		},
 		"yargs": {
 			"version": "17.5.1",

--- a/user-service/package.json
+++ b/user-service/package.json
@@ -19,13 +19,17 @@
 	},
 	"dependencies": {
 		"bcryptjs": "^2.4.3",
+		"body-parser": "^1.20.0",
 		"cookie-parser": "^1.4.6",
 		"cors": "^2.8.5",
 		"dotenv": "^16.0.1",
 		"express": "^4.18.1",
 		"express-async-handler": "^1.2.0",
+		"express-jwt-blacklist": "^1.1.0",
 		"jsonwebtoken": "^8.5.1",
 		"mongoose": "^6.4.5",
+		"redis": "^4.3.1",
+		"redis-server": "^1.2.2",
 		"require": "^2.4.20"
 	}
 }


### PR DESCRIPTION
Added Redis to allow for caching of blacklisted tokens. 

Entries are stored in a key-value pair, with the token being the key and the username being the value. This is because when getting the dashboard page, there are no references to the username.

Current implementation requires the user to run the redis-server locally, will try to use redis cloud if can.